### PR TITLE
modify platforms of default. 'darwin' => 'darwin-x64'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When you run code under `process.NODE_ENV = test` more debug information will be
 * `cache` The download path for the electron package, **required**.
 * `release` is where the release applictions path, **required**.
 * `version` the version of the electron release to be download from the GitHub page, **required**.
-* `platforms` Support `['darwin','win32','linux','darwin-x64','linux-ia32','linux-x64','win32-ia32','win64-64']`, default is `darwin`. If verion is under `v0.13.0` must use `['darwin','win32','linux']`.
+* `platforms` Support `['darwin','win32','linux','darwin-x64','linux-ia32','linux-x64','win32-ia32','win64-64']`, default is `darwin-x64`. If verion is under `v0.13.0` must use `['darwin','win32','linux']`.
 * `apm` Path to the `atom-package-manager` executable. If not specified the default behavior will be to use the globally installed `apm` executable.
 * `rebuild` Default is `false`, when set to `true` the native `electron` modules will be rebuilt.
 * `symbols` Default is `false`, when set to `true` the symbols package from GitHub will be downloaded.

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ module.exports = electron = function(options) {
     packageJson = require(packageJson);
   }
   if (options.platforms == null) {
-    options.platforms = ['darwin'];
+    options.platforms = ['darwin-x64'];
   }
   if (options.apm == null) {
     options.apm = getApmPath();


### PR DESCRIPTION
electronのdefault platformsは 'darwin' ですが、
'darwin' はatom-shell の v0.13.0より前の名前で
electronになってからは、
'electron-v0.x.x-darwin-x64.zip' しかなく、'electron-v0.25.1-darwin.zip'
はないためダウンロードで失敗するため、
defaultの名前も'darwin-x64' にした方がいいと思いました。
