### PR TITLE
Major bug found. Specifying `src: '.'`

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -178,10 +178,18 @@ module.exports = electron = (options) ->
           (next) ->
             util.log PLUGIN_NAME, "#{options.src} -> #{targetDir} distributing"
             wrench.mkdirSyncRecursive targetDirPath
-            wrench.copyDirSyncRecursive options.src, targetDirPath,
-              forceDelete: true
-              excludeHiddenUnix: false
-              inflateSymlinks: false
+
+            # Major bug here
+            # if src: '.', then you end up with a full disk and an undeletable folder
+            # You should use the gulp src list instead
+            # e.g.
+            # gulp.src(['*.js', '*.json'])
+            #     .pipe(electron({ ... }))
+            #     .pipe(gulp.dest('release'))
+            #wrench.copyDirSyncRecursive options.src, targetDirPath,
+            #  forceDelete: true
+            #  excludeHiddenUnix: false
+            #  inflateSymlinks: false
             next()
 
           # packaging app.


### PR DESCRIPTION
For some reason I am unable to report issues on your project so I am creating a pull request with information about this issue. I do not know how to actually fix it. I am unable to successfully use this task as is. 

This can fill your harddisk with an undeletable folder due to recursively copying itself over and over.

I believe it should accept a source list instead of just recursively copying an entire folder
e.g. `['*.js', '*.html']`
