### PR TITLE
Fix packaging for Linux. Fix #19.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,7 @@ module.exports = electron = function(options) {
         targetZip = ".";
       } else {
         electronFile = "electron";
+        targetZip = ".";
       }
       electronFileDir = path.join(platformDir, electronFile);
       electronFilePath = path.resolve(electronFileDir);

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -118,6 +118,7 @@ module.exports = electron = (options) ->
         targetZip = "."
       else
         electronFile = "electron"
+        targetZip = "."
       # ex: ./release/v0.24.0/darwin-x64/Electron
       electronFileDir = path.join platformDir, electronFile
       electronFilePath = path.resolve electronFileDir


### PR DESCRIPTION
This fixes packaging for Linux by setting the `targetZip` variable as outlined in #19.
