### PR TITLE
add linux-arm to supported platforms

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ module.exports = electron = function(options) {
   endStream = function(callback) {
     var platforms, push;
     push = this.push;
-    platforms = ['darwin', 'win32', 'linux', 'darwin-x64', 'linux-ia32', 'linux-x64', 'win32-ia32', 'win32-x64'];
+    platforms = ['darwin', 'win32', 'linux', 'darwin-x64', 'linux-ia32', 'linux-x64', 'win32-ia32', 'win32-x64', 'linux-arm'];
     return Promise.map(options.platforms, function(platform) {
       var _src, binName, cache, cacheFile, cachePath, cacheZip, cacheedPath, defaultAppName, electronFile, electronFileDir, electronFilePath, identity, packagingCmd, pkg, pkgZip, pkgZipDir, pkgZipFilePath, pkgZipPath, platformDir, platformPath, ref, ref1, suffix, targetApp, targetAppDir, targetAppPath, targetAsarPath, targetDir, targetDirPath, targetZip, unpackagingCmd;
       if (platform === 'osx') {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -74,7 +74,8 @@ module.exports = electron = (options) ->
     'linux-ia32',
     'linux-x64',
     'win32-ia32',
-    'win32-x64']
+    'win32-x64',
+    'linux-arm']
 
     Promise.map options.platforms, (platform) ->
       platform = 'darwin' if platform is 'osx'


### PR DESCRIPTION
Task will download `linux-arm` but not allow building with it because it's not in the platform list.
