### PR TITLE
Add support for flowing GitHub auth token to grs().

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ gulp.task('electron', function() {
         cache: './cache',
         version: 'v0.26.1',
         packaging: true,
+        token: 'abc123...',
         platforms: ['win32-ia32', 'darwin-x64'],
         platformResources: {
             darwin: {
@@ -79,6 +80,7 @@ If you using windows: install 7z(http://www.7-zip.org/).
 * `asarUnpackDir` Default is `false`, this options filter out asar directory, ex: `vendor` filter out `vendor` dir.
 * `symbols` Default is `false`, when set to `true` the symbols package from GitHub will be downloaded.
 * `packaging` Default is `false`, when set to `true` the packaging zip file.
+* `token` Default is `undefined`, when set to a GitHub authentication token helps prevent rate-limits when downloading Electron releases.
 
 * `platformResources`
   * `darwin` Mac resources. See [Core Foundation Keys](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html) for details.

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,7 @@ module.exports = electron = function(options) {
       };
       return new Promise(function(resolve, reject) {
         return Promise.resolve().then(function() {
-          return download(cacheFile, cachePath, options.version, cacheZip);
+          return download(cacheFile, cachePath, options.version, cacheZip, options.token);
         }).then(function() {
           return unzip(cacheFile, cacheedPath, unpackagingCmd[process.platform]);
         }).then(function() {
@@ -329,7 +329,7 @@ getApmPath = function() {
   }
 };
 
-download = function(cacheFile, cachePath, version, cacheZip) {
+download = function(cacheFile, cachePath, version, cacheZip, token) {
   if (isFile(cacheFile)) {
     util.log(PLUGIN_NAME, "download skip: already exists");
     return Promise.resolve();
@@ -342,7 +342,8 @@ download = function(cacheFile, cachePath, version, cacheZip) {
     return grs({
       repo: 'atom/electron',
       tag: version,
-      name: cacheZip
+      name: cacheZip,
+      token: token
     }).on('error', function(error) {
       throw new PluginError(PLUGIN_NAME, error);
     }).on('size', function(size) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -196,7 +196,7 @@ module.exports = electron = (options) ->
       new Promise (resolve,reject) ->
         Promise.resolve().then ->
           # If not downloaded then download the special package.
-          download cacheFile, cachePath, options.version, cacheZip
+          download cacheFile, cachePath, options.version, cacheZip, options.token
         .then ->
           # If not unziped then unzip the zip file.
           # Check if there already have an version file.
@@ -269,7 +269,7 @@ getApmPath = ->
   apmPath = path.join 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm'
   apmPath = 'apm' unless isFile apmPath
 
-download = (cacheFile, cachePath, version, cacheZip) ->
+download = (cacheFile, cachePath, version, cacheZip, token) ->
   if isFile cacheFile
     util.log PLUGIN_NAME, "download skip: already exists"
     return Promise.resolve()
@@ -282,6 +282,7 @@ download = (cacheFile, cachePath, version, cacheZip) ->
       repo: 'atom/electron'
       tag: version
       name: cacheZip
+      token: token
     .on 'error', (error) ->
       throw new PluginError PLUGIN_NAME, error
     .on 'size', (size) ->


### PR DESCRIPTION
Adds an optional `token` property to the `gulp-electron` options for the GitHub authentication token used when downloading Electron images (via `grs`).  This helps avoid rate-limiting in frequent CI builds that involve packaging Electron apps.
