### PR TITLE
Remove app dir after creating app.asar

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -408,7 +408,7 @@ asarPackaging = (src, target, opts) ->
     util.log PLUGIN_NAME, "packaging app.asar #{escSrc}, #{escTarget}"
     asar.createPackageWithOptions escSrc, escTarget, opts, ->
       fs.remove escSrc, ->
-        util.log PLUGIN_NAME, 'removing app dir' + escSrc
+        util.log PLUGIN_NAME, 'removing dir ' + escSrc
         resolve()
       return
 

--- a/index.coffee
+++ b/index.coffee
@@ -408,9 +408,9 @@ asarPackaging = (src, target, opts) ->
     util.log PLUGIN_NAME, "packaging app.asar #{escSrc}, #{escTarget}"
     asar.createPackageWithOptions escSrc, escTarget, opts, ->
       fs.remove escSrc, (err) ->
-        util.log PLUGIN_NAME, "removing dir " + escSrc
+        util.log PLUGIN_NAME, 'removing dir ' + escSrc
         resolve()
-      return
+        return
 
 signDarwin = (signingCmd) ->
   promiseList = []

--- a/index.coffee
+++ b/index.coffee
@@ -411,6 +411,7 @@ asarPackaging = (src, target, opts) ->
         util.log PLUGIN_NAME, 'removing dir ' + escSrc
         resolve()
         return
+      return
 
 signDarwin = (signingCmd) ->
   promiseList = []

--- a/index.coffee
+++ b/index.coffee
@@ -407,7 +407,10 @@ asarPackaging = (src, target, opts) ->
   new Promise (resolve) ->
     util.log PLUGIN_NAME, "packaging app.asar #{escSrc}, #{escTarget}"
     asar.createPackageWithOptions escSrc, escTarget, opts, ->
-      resolve()
+      fs.remove escSrc, ->
+        util.log PLUGIN_NAME, 'removing app ' + escSrc
+        resolve()
+      return
 
 signDarwin = (signingCmd) ->
   promiseList = []

--- a/index.coffee
+++ b/index.coffee
@@ -407,8 +407,8 @@ asarPackaging = (src, target, opts) ->
   new Promise (resolve) ->
     util.log PLUGIN_NAME, "packaging app.asar #{escSrc}, #{escTarget}"
     asar.createPackageWithOptions escSrc, escTarget, opts, ->
-      fs.remove escSrc, ->
-        util.log PLUGIN_NAME, 'removing dir ' + escSrc
+      fs.remove escSrc, (err) ->
+        util.log PLUGIN_NAME, "removing dir " + escSrc
         resolve()
       return
 

--- a/index.coffee
+++ b/index.coffee
@@ -408,7 +408,7 @@ asarPackaging = (src, target, opts) ->
     util.log PLUGIN_NAME, "packaging app.asar #{escSrc}, #{escTarget}"
     asar.createPackageWithOptions escSrc, escTarget, opts, ->
       fs.remove escSrc, ->
-        util.log PLUGIN_NAME, 'removing app ' + escSrc
+        util.log PLUGIN_NAME, 'removing app dir' + escSrc
         resolve()
       return
 

--- a/index.js
+++ b/index.js
@@ -503,7 +503,10 @@ asarPackaging = function(src, target, opts) {
   return new Promise(function(resolve) {
     util.log(PLUGIN_NAME, "packaging app.asar " + escSrc + ", " + escTarget);
     return asar.createPackageWithOptions(escSrc, escTarget, opts, function() {
-      return resolve();
+      fs.remove(escSrc, function() {
+        util.log(PLUGIN_NAME, 'removing app ' + escSrc);
+        return resolve();
+      });
     });
   });
 };

--- a/index.js
+++ b/index.js
@@ -503,9 +503,9 @@ asarPackaging = function(src, target, opts) {
   return new Promise(function(resolve) {
     util.log(PLUGIN_NAME, "packaging app.asar " + escSrc + ", " + escTarget);
     return asar.createPackageWithOptions(escSrc, escTarget, opts, function() {
-      fs.remove(escSrc, function(err) {
-        util.log(PLUGIN_NAME, "removing dir " + escSrc);
-        return resolve();
+      return fs.remove(escSrc, function(err) {
+        util.log(PLUGIN_NAME, 'removing dir ' + escSrc);
+        resolve();
       });
     });
   });

--- a/index.js
+++ b/index.js
@@ -503,7 +503,7 @@ asarPackaging = function(src, target, opts) {
   return new Promise(function(resolve) {
     util.log(PLUGIN_NAME, "packaging app.asar " + escSrc + ", " + escTarget);
     return asar.createPackageWithOptions(escSrc, escTarget, opts, function() {
-      return fs.remove(escSrc, function(err) {
+      fs.remove(escSrc, function(err) {
         util.log(PLUGIN_NAME, 'removing dir ' + escSrc);
         resolve();
       });

--- a/index.js
+++ b/index.js
@@ -503,8 +503,8 @@ asarPackaging = function(src, target, opts) {
   return new Promise(function(resolve) {
     util.log(PLUGIN_NAME, "packaging app.asar " + escSrc + ", " + escTarget);
     return asar.createPackageWithOptions(escSrc, escTarget, opts, function() {
-      fs.remove(escSrc, function() {
-        util.log(PLUGIN_NAME, 'removing dir ' + escSrc);
+      fs.remove(escSrc, function(err) {
+        util.log(PLUGIN_NAME, "removing dir " + escSrc);
         return resolve();
       });
     });

--- a/index.js
+++ b/index.js
@@ -504,7 +504,7 @@ asarPackaging = function(src, target, opts) {
     util.log(PLUGIN_NAME, "packaging app.asar " + escSrc + ", " + escTarget);
     return asar.createPackageWithOptions(escSrc, escTarget, opts, function() {
       fs.remove(escSrc, function() {
-        util.log(PLUGIN_NAME, 'removing app ' + escSrc);
+        util.log(PLUGIN_NAME, 'removing dir ' + escSrc);
         return resolve();
       });
     });


### PR DESCRIPTION
If we selected asar packaging then this should remove app directory in resources and leave only app.asar.
