### PR TITLE
Log when the windows exe metadata patching fails

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -394,8 +394,10 @@ distributeMacIcon = (src, targetAppPath) ->
 
 distributeWinIcon = (src, targetAppPath) ->
   new Promise (resolve) ->
-    rcedit targetAppPath, src, resolve
-    resolve()
+    rcedit targetAppPath, src, (err) ->
+      if err?
+        util.log PLUGIN_NAME, "distributeWinIcon #{err}"
+      resolve()
 
 rebuild = (cmd) ->
   new Promise (resolve) ->

--- a/index.js
+++ b/index.js
@@ -485,8 +485,12 @@ distributeMacIcon = function(src, targetAppPath) {
 
 distributeWinIcon = function(src, targetAppPath) {
   return new Promise(function(resolve) {
-    rcedit(targetAppPath, src, resolve);
-    return resolve();
+    return rcedit(targetAppPath, src, function(err) {
+      if (err != null) {
+        util.log(PLUGIN_NAME, "distributeWinIcon " + err);
+      }
+      return resolve();
+    });
   });
 };
 


### PR DESCRIPTION
We ran into an issue where the windows exe metadata was not being patched properly and as such we had to work out what was happening. The issue turned out to be a mistake we made where the icon file was in the wrong path, however there were no errors logged to let us know there was an issue.

This PR adds some logging when an error occurs patching the metadata. It also delegates responsibility for resolving the promise to the rcedit callback function.